### PR TITLE
Add link to home to improve navigation

### DIFF
--- a/src/components/profile-header/profile-header.scss
+++ b/src/components/profile-header/profile-header.scss
@@ -1,9 +1,14 @@
+profile-header{
+  stencil-route-link a {
+    text-decoration: none;
+  }
+}
 
 ion-icon {
   fill: white;
   width: 32px;
 }
-    
+
 #userImage {
   border-radius: 50%;
   height: 3em;

--- a/src/components/profile-header/profile-header.tsx
+++ b/src/components/profile-header/profile-header.tsx
@@ -40,7 +40,7 @@ export class ProfileHeader {
       component: 'popover-page',
       ev: event
     });
-    
+
     await this.popover.present();
   }
 
@@ -72,7 +72,7 @@ export class ProfileHeader {
     return (
       <ion-header md-height="96px">
         <ion-toolbar color='dark'>
-          <ion-title>IonicBeer Beta</ion-title>
+          <stencil-route-link url='/' exact={true}><ion-title>IonicBeer Beta</ion-title></stencil-route-link>
 
           <ion-buttons slot='end'>
             <ion-button fill='clear' onClick={() => this.openPopover(event)} icon-only>

--- a/src/components/profile-page/profile-page.scss
+++ b/src/components/profile-page/profile-page.scss
@@ -1,5 +1,9 @@
 profile-page {
 
+  stencil-route-link a {
+    text-decoration: none;
+  }
+
   ion-page {
     background: white;
   }

--- a/src/components/profile-page/profile-page.tsx
+++ b/src/components/profile-page/profile-page.tsx
@@ -91,7 +91,7 @@ export class ProfilePage {
         <ion-page class='show-page'>
           <ion-header md-height="96px">
             <ion-toolbar color='dark'>
-              <ion-title>IonicBeer Beta</ion-title>
+              <stencil-route-link url='/' exact={true}><ion-title>IonicBeer Beta</ion-title></stencil-route-link>
             </ion-toolbar>
           </ion-header>
 
@@ -115,7 +115,7 @@ export class ProfilePage {
       <ion-page class='show-page'>
         <ion-header md-height="96px">
           <ion-toolbar color='dark'>
-            <ion-title>IonicBeer Beta</ion-title>
+            <stencil-route-link url='/' exact={true}><ion-title>IonicBeer Beta</ion-title></stencil-route-link>
           </ion-toolbar>
         </ion-header>
 


### PR DESCRIPTION
Link to home added on profile-header & profile-page. I don’t understand
why the SASS rule on profile-header.scss for the link is not working.